### PR TITLE
Add appmesh:StreamAggregatedResources to appmesh worker policy

### DIFF
--- a/content/servicemesh_with_appmesh/create_the_k8s_app/set_perms.md
+++ b/content/servicemesh_with_appmesh/create_the_k8s_app/set_perms.md
@@ -78,7 +78,8 @@ cat <<EoF > k8s-appmesh-worker-policy.json
         "appmesh:DeleteVirtualNode",
         "appmesh:DeleteVirtualService",
         "appmesh:DeleteVirtualRouter",
-        "appmesh:DeleteRoute"
+        "appmesh:DeleteRoute",
+        "appmesh:StreamAggregatedResources",
   ],
       "Resource": "*"
     }


### PR DESCRIPTION
appmesh workers soon need the `appmesh:StreamAggregatedResources` permission to fetch configuration for Envoy.

aws/aws-app-mesh-roadmap/issues/80 explains more.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
